### PR TITLE
Add WhatsApp contact button and wholesale minimum notice

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,6 @@
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "./Sidebar";
-import { Bell, Search, User } from "lucide-react";
+import { Bell, MessageCircle, Search, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -13,7 +13,7 @@ export function Layout({ children }: LayoutProps) {
     <SidebarProvider>
       <div className="min-h-screen flex w-full bg-gradient-to-br from-background via-background to-muted/30">
         <AppSidebar />
-        
+
         <div className="flex-1 flex flex-col">
           {/* Header */}
           <header className="h-16 border-b bg-card/50 backdrop-blur-sm flex items-center justify-between px-6">
@@ -51,6 +51,24 @@ export function Layout({ children }: LayoutProps) {
             {children}
           </main>
         </div>
+      </div>
+
+      <div className="fixed bottom-6 right-6 z-50">
+        <Button
+          asChild
+          size="lg"
+          className="bg-emerald-500 hover:bg-emerald-600 text-white shadow-lg shadow-emerald-500/30 rounded-full px-5"
+        >
+          <a
+            href="https://wa.me/33612345678?text=Bonjour%2C%20je%20souhaite%20obtenir%20un%20devis%20personnalis%C3%A9."
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Demander un devis personnalisé via WhatsApp"
+          >
+            <MessageCircle className="h-5 w-5" />
+            <span className="hidden sm:inline">WhatsApp</span>
+          </a>
+        </Button>
       </div>
     </SidebarProvider>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,15 +2,17 @@ import { Layout } from "@/components/layout/Layout";
 import { KPICard } from "@/components/dashboard/KPICard";
 import { ActivityFeed } from "@/components/dashboard/ActivityFeed";
 import { RevenueChart } from "@/components/dashboard/RevenueChart";
-import { 
-  Users, 
-  FolderOpen, 
-  FileText, 
-  Euro, 
-  Building2, 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Users,
+  FolderOpen,
+  FileText,
+  Euro,
+  Building2,
   TrendingUp,
   Calendar,
-  Target
+  Target,
+  Package
 } from "lucide-react";
 
 const Index = () => {
@@ -32,6 +34,15 @@ const Index = () => {
             <p className="text-sm font-medium">Aujourd'hui à 14:30</p>
           </div>
         </div>
+
+        <Alert className="border-emerald-200 bg-emerald-50 text-emerald-900">
+          <Package className="h-4 w-4" />
+          <AlertTitle>Vente en gros uniquement</AlertTitle>
+          <AlertDescription className="space-y-1">
+            <p>Nos offres sont réservées au grossiste avec un minimum de commande de 10 pièces.</p>
+            <p>Utilisez WhatsApp pour demander un devis personnalisé adapté à vos besoins.</p>
+          </AlertDescription>
+        </Alert>
 
         {/* KPI Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">


### PR DESCRIPTION
## Summary
- add a floating WhatsApp contact button so users can request personalized quotes from any dashboard screen
- highlight the wholesale-only minimum order requirement on the main dashboard

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafce4674883338788c1c468fb7266