### PR TITLE
Add quotes and invoices management dashboards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { ThemeProvider } from "@/components/theme-provider";
 import Index from "./pages/Index";
 import Leads from "./pages/Leads";
 import Projects from "./pages/Projects";
+import Quotes from "./pages/Quotes";
+import Invoices from "./pages/Invoices";
 import Sites from "./pages/Sites";
 import Products from "./pages/Products";
 import Auth from "./pages/Auth";
@@ -29,8 +31,8 @@ const App = () => (
               <Route path="/" element={<ProtectedRoute><Index /></ProtectedRoute>} />
               <Route path="/leads" element={<ProtectedRoute><Leads /></ProtectedRoute>} />
               <Route path="/projects" element={<ProtectedRoute><Projects /></ProtectedRoute>} />
-              <Route path="/quotes" element={<ProtectedRoute><Index /></ProtectedRoute>} />
-              <Route path="/invoices" element={<ProtectedRoute><Index /></ProtectedRoute>} />
+              <Route path="/quotes" element={<ProtectedRoute><Quotes /></ProtectedRoute>} />
+              <Route path="/invoices" element={<ProtectedRoute><Invoices /></ProtectedRoute>} />
               <Route path="/sites" element={<ProtectedRoute><Sites /></ProtectedRoute>} />
               <Route path="/products" element={<ProtectedRoute><Products /></ProtectedRoute>} />
               <Route path="/calendar" element={<ProtectedRoute><Index /></ProtectedRoute>} />

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -1,0 +1,338 @@
+import { Layout } from "@/components/layout/Layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Search,
+  Filter,
+  PlusCircle,
+  FileDown,
+  Mail,
+  FileCheck,
+  AlarmClock,
+  Euro,
+  Eye,
+  Send,
+} from "lucide-react";
+
+interface Invoice {
+  id: string;
+  reference: string;
+  client: string;
+  project?: string;
+  amount: number;
+  status: "DRAFT" | "SENT" | "PAID" | "OVERDUE";
+  dueDate: string;
+  issueDate: string;
+  facturx: boolean;
+  paymentMethod?: string;
+}
+
+const mockInvoices: Invoice[] = [
+  {
+    id: "f1",
+    reference: "FAC-2024-0098",
+    client: "Sophie Bernard",
+    project: "Isolation Façade",
+    amount: 18500,
+    status: "PAID",
+    dueDate: "2024-03-15",
+    issueDate: "2024-03-01",
+    facturx: true,
+    paymentMethod: "Virement SEPA",
+  },
+  {
+    id: "f2",
+    reference: "FAC-2024-0099",
+    client: "Jean Martin",
+    project: "Pompe à chaleur",
+    amount: 14200,
+    status: "SENT",
+    dueDate: "2024-03-30",
+    issueDate: "2024-03-05",
+    facturx: true,
+  },
+  {
+    id: "f3",
+    reference: "FAC-2024-0100",
+    client: "Marie Dupont",
+    project: "Isolation combles",
+    amount: 6200,
+    status: "DRAFT",
+    dueDate: "2024-04-05",
+    issueDate: "2024-03-12",
+    facturx: false,
+  },
+  {
+    id: "f4",
+    reference: "FAC-2024-0101",
+    client: "SARL Les Halles",
+    project: "Rénovation éclairage",
+    amount: 9800,
+    status: "OVERDUE",
+    dueDate: "2024-03-10",
+    issueDate: "2024-02-25",
+    facturx: true,
+  },
+];
+
+const statusMeta: Record<Invoice["status"], { label: string; className: string }> = {
+  DRAFT: {
+    label: "Brouillon",
+    className: "bg-gray-500/10 text-gray-700 border-gray-200",
+  },
+  SENT: {
+    label: "Envoyée",
+    className: "bg-blue-500/10 text-blue-700 border-blue-200",
+  },
+  PAID: {
+    label: "Payée",
+    className: "bg-green-500/10 text-green-700 border-green-200",
+  },
+  OVERDUE: {
+    label: "En retard",
+    className: "bg-red-500/10 text-red-700 border-red-200",
+  },
+};
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    maximumFractionDigits: 0,
+  }).format(value);
+
+const getTotals = () => {
+  const totalBilled = mockInvoices.reduce((acc, invoice) => acc + invoice.amount, 0);
+  const totalPaid = mockInvoices
+    .filter((invoice) => invoice.status === "PAID")
+    .reduce((acc, invoice) => acc + invoice.amount, 0);
+  const totalOverdue = mockInvoices
+    .filter((invoice) => invoice.status === "OVERDUE")
+    .reduce((acc, invoice) => acc + invoice.amount, 0);
+
+  return { totalBilled, totalPaid, totalOverdue };
+};
+
+const Invoices = () => {
+  const { totalBilled, totalPaid, totalOverdue } = getTotals();
+  const collectionRate = Math.round((totalPaid / totalBilled) * 100);
+
+  return (
+    <Layout>
+      <div className="space-y-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
+              Gestion des Factures
+            </h1>
+            <p className="text-muted-foreground mt-1">
+              Pilotage des encaissements et conformité Factur-X 2026
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline">
+              <FileDown className="w-4 h-4 mr-2" />
+              Exporter Factur-X
+            </Button>
+            <Button variant="outline">
+              <Send className="w-4 h-4 mr-2" />
+              Relance email
+            </Button>
+            <Button>
+              <PlusCircle className="w-4 h-4 mr-2" />
+              Nouvelle Facture
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+          <Card className="shadow-card border-0 bg-gradient-to-br from-primary/10 to-primary/5">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">Total facturé</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-primary">{formatCurrency(totalBilled)}</p>
+              <p className="text-xs text-muted-foreground">Montant cumulé toutes factures</p>
+            </CardContent>
+          </Card>
+          <Card className="shadow-card border-0 bg-gradient-to-br from-green-500/10 via-green-500/5 to-transparent">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">Total encaissé</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-green-600">{formatCurrency(totalPaid)}</p>
+              <div className="mt-2 space-y-2">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>Taux d'encaissement</span>
+                  <span>{collectionRate}%</span>
+                </div>
+                <Progress value={collectionRate} className="h-2" />
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="shadow-card border-0 bg-gradient-to-br from-red-500/10 via-red-500/5 to-transparent">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">Montant en retard</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-red-600">{formatCurrency(totalOverdue)}</p>
+              <p className="text-xs text-muted-foreground">Relances prioritaires à effectuer</p>
+            </CardContent>
+          </Card>
+          <Card className="shadow-card border-0 bg-gradient-to-br from-blue-500/10 via-blue-500/5 to-transparent">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">Factures Factur-X</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-blue-600">
+                {mockInvoices.filter((invoice) => invoice.facturx).length}/{mockInvoices.length}
+              </p>
+              <p className="text-xs text-muted-foreground">Prêtes pour l'obligation 2026</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card className="shadow-card bg-gradient-card border-0">
+          <CardContent className="pt-6">
+            <div className="flex flex-col md:flex-row gap-4">
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                <Input placeholder="Rechercher par client, référence ou chantier" className="pl-10" />
+              </div>
+              <Button variant="outline">
+                <Filter className="w-4 h-4 mr-2" />
+                Filtres avancés
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+          <Card className="shadow-card bg-gradient-card border-0 xl:col-span-2">
+            <CardHeader>
+              <CardTitle>Liste des factures ({mockInvoices.length})</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Référence</TableHead>
+                    <TableHead>Client</TableHead>
+                    <TableHead>Projet</TableHead>
+                    <TableHead>Montant</TableHead>
+                    <TableHead>Échéance</TableHead>
+                    <TableHead>Statut</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {mockInvoices.map((invoice) => (
+                    <TableRow key={invoice.id}>
+                      <TableCell className="font-medium">
+                        <div className="flex flex-col">
+                          <span>{invoice.reference}</span>
+                          <span className="text-xs text-muted-foreground">Émise le {invoice.issueDate}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-medium">{invoice.client}</span>
+                          {invoice.paymentMethod && (
+                            <span className="text-xs text-muted-foreground">{invoice.paymentMethod}</span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <Euro className="w-4 h-4 text-muted-foreground" />
+                          <span>{invoice.project ?? "-"}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="font-semibold">{formatCurrency(invoice.amount)}</TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2 text-sm">
+                          <AlarmClock className="w-4 h-4 text-muted-foreground" />
+                          <span>{invoice.dueDate}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-col gap-1">
+                          <Badge variant="outline" className={statusMeta[invoice.status].className}>
+                            {statusMeta[invoice.status].label}
+                          </Badge>
+                          {invoice.facturx && (
+                            <Badge variant="outline" className="w-fit bg-blue-500/10 text-blue-700 border-blue-200">
+                              Factur-X
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-2">
+                          <Button variant="ghost" size="icon">
+                            <Eye className="w-4 h-4" />
+                          </Button>
+                          <Button variant="ghost" size="icon">
+                            <Mail className="w-4 h-4" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          <Card className="shadow-card bg-gradient-card border-0">
+            <CardHeader>
+              <CardTitle>Relances & conformité</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex gap-3 p-3 rounded-lg border bg-background/60">
+                <AlarmClock className="w-5 h-5 text-orange-500 mt-1" />
+                <div>
+                  <p className="font-medium">Factures à relancer</p>
+                  <p className="text-sm text-muted-foreground">
+                    {mockInvoices.filter((invoice) => invoice.status === "OVERDUE").length} factures dépassent l'échéance
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-3 p-3 rounded-lg border bg-background/60">
+                <FileCheck className="w-5 h-5 text-green-500 mt-1" />
+                <div>
+                  <p className="font-medium">Factur-X généré</p>
+                  <p className="text-sm text-muted-foreground">
+                    {mockInvoices.filter((invoice) => invoice.facturx).length} factures prêtes au format hybride XML/PDF
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-3 p-3 rounded-lg border bg-background/60">
+                <Mail className="w-5 h-5 text-blue-500 mt-1" />
+                <div>
+                  <p className="font-medium">Envoyer par email</p>
+                  <p className="text-sm text-muted-foreground">
+                    Synchronisation SMTP OVH pour l'envoi direct aux clients
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default Invoices;

--- a/src/pages/Quotes.tsx
+++ b/src/pages/Quotes.tsx
@@ -1,0 +1,329 @@
+import { Layout } from "@/components/layout/Layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Search,
+  Filter,
+  PlusCircle,
+  FileDown,
+  FileSpreadsheet,
+  CheckCircle2,
+  Timer,
+  Send,
+  Eye,
+} from "lucide-react";
+
+interface Quote {
+  id: string;
+  reference: string;
+  client: string;
+  project?: string;
+  product: string;
+  amount: number;
+  status: "DRAFT" | "SENT" | "ACCEPTED" | "REJECTED";
+  validityDate: string;
+  createdAt: string;
+  ceeEligible: boolean;
+  notes?: string;
+}
+
+const mockQuotes: Quote[] = [
+  {
+    id: "q1",
+    reference: "DEV-2024-0152",
+    client: "Sophie Bernard",
+    project: "Isolation Façade",
+    product: "Isolation Thermique Extérieure",
+    amount: 18500,
+    status: "ACCEPTED",
+    validityDate: "2024-04-05",
+    createdAt: "2024-03-01",
+    ceeEligible: true,
+    notes: "Prime CEE estimée à 5 200€"
+  },
+  {
+    id: "q2",
+    reference: "DEV-2024-0153",
+    client: "Jean Martin",
+    project: "Pompe à chaleur",
+    product: "Pompe à chaleur air/eau",
+    amount: 14200,
+    status: "SENT",
+    validityDate: "2024-03-28",
+    createdAt: "2024-03-05",
+    ceeEligible: true,
+  },
+  {
+    id: "q3",
+    reference: "DEV-2024-0154",
+    client: "Marie Dupont",
+    project: "Isolation combles",
+    product: "Isolation combles perdus",
+    amount: 6200,
+    status: "DRAFT",
+    validityDate: "2024-04-12",
+    createdAt: "2024-03-10",
+    ceeEligible: false,
+  },
+  {
+    id: "q4",
+    reference: "DEV-2024-0155",
+    client: "SARL Les Halles",
+    project: "Rénovation éclairage",
+    product: "LED Haute performance",
+    amount: 9800,
+    status: "REJECTED",
+    validityDate: "2024-03-15",
+    createdAt: "2024-02-28",
+    ceeEligible: false,
+    notes: "Budget non validé par le client"
+  }
+];
+
+const statusMeta: Record<Quote["status"], { label: string; className: string }> = {
+  DRAFT: {
+    label: "Brouillon",
+    className: "bg-gray-500/10 text-gray-700 border-gray-200",
+  },
+  SENT: {
+    label: "Envoyé",
+    className: "bg-blue-500/10 text-blue-700 border-blue-200",
+  },
+  ACCEPTED: {
+    label: "Accepté",
+    className: "bg-green-500/10 text-green-700 border-green-200",
+  },
+  REJECTED: {
+    label: "Refusé",
+    className: "bg-red-500/10 text-red-700 border-red-200",
+  },
+};
+
+const getConversionRate = () => {
+  const accepted = mockQuotes.filter((quote) => quote.status === "ACCEPTED").length;
+  return Math.round((accepted / mockQuotes.length) * 100);
+};
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    maximumFractionDigits: 0,
+  }).format(value);
+
+const Quotes = () => {
+  const totals = {
+    draft: mockQuotes.filter((quote) => quote.status === "DRAFT").length,
+    sent: mockQuotes.filter((quote) => quote.status === "SENT").length,
+    accepted: mockQuotes.filter((quote) => quote.status === "ACCEPTED").length,
+    rejected: mockQuotes.filter((quote) => quote.status === "REJECTED").length,
+    cee: mockQuotes.filter((quote) => quote.ceeEligible).length,
+  };
+
+  return (
+    <Layout>
+      <div className="space-y-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
+              Gestion des Devis
+            </h1>
+            <p className="text-muted-foreground mt-1">
+              Suivi complet des propositions commerciales et conformité Factur-X
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline">
+              <FileSpreadsheet className="w-4 h-4 mr-2" />
+              Importer CSV
+            </Button>
+            <Button variant="outline">
+              <FileDown className="w-4 h-4 mr-2" />
+              Exporter
+            </Button>
+            <Button>
+              <PlusCircle className="w-4 h-4 mr-2" />
+              Nouveau Devis
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+          <Card className="shadow-card border-0 bg-gradient-to-br from-primary/10 to-primary/5">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">Devis en brouillon</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-primary">{totals.draft}</p>
+              <p className="text-xs text-muted-foreground">À finaliser avant envoi</p>
+            </CardContent>
+          </Card>
+          <Card className="shadow-card border-0 bg-gradient-to-br from-blue-500/10 via-blue-500/5 to-transparent">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">Devis envoyés</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-blue-600">{totals.sent}</p>
+              <p className="text-xs text-muted-foreground">En attente de réponse</p>
+            </CardContent>
+          </Card>
+          <Card className="shadow-card border-0 bg-gradient-to-br from-green-500/10 via-green-500/5 to-transparent">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">Devis acceptés</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-green-600">{totals.accepted}</p>
+              <p className="text-xs text-muted-foreground">Taux de conversion {getConversionRate()}%</p>
+            </CardContent>
+          </Card>
+          <Card className="shadow-card border-0 bg-gradient-to-br from-orange-500/10 via-orange-500/5 to-transparent">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">Eligibles CEE</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-orange-500">{totals.cee}</p>
+              <p className="text-xs text-muted-foreground">Suivi des primes en cours</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card className="shadow-card bg-gradient-card border-0">
+          <CardContent className="pt-6">
+            <div className="flex flex-col md:flex-row gap-4">
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                <Input placeholder="Rechercher par client, référence ou solution" className="pl-10" />
+              </div>
+              <Button variant="outline">
+                <Filter className="w-4 h-4 mr-2" />
+                Filtres avancés
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+          <Card className="shadow-card bg-gradient-card border-0 xl:col-span-2">
+            <CardHeader>
+              <CardTitle>Liste des devis ({mockQuotes.length})</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Référence</TableHead>
+                    <TableHead>Client</TableHead>
+                    <TableHead>Solution</TableHead>
+                    <TableHead>Montant</TableHead>
+                    <TableHead>Validité</TableHead>
+                    <TableHead>Statut</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {mockQuotes.map((quote) => (
+                    <TableRow key={quote.id}>
+                      <TableCell className="font-medium">
+                        <div className="flex flex-col">
+                          <span>{quote.reference}</span>
+                          <span className="text-xs text-muted-foreground">Créé le {quote.createdAt}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-medium">{quote.client}</span>
+                          {quote.project && (
+                            <span className="text-xs text-muted-foreground">{quote.project}</span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-col gap-1">
+                          <span>{quote.product}</span>
+                          {quote.ceeEligible && (
+                            <Badge variant="outline" className="w-fit bg-emerald-500/10 text-emerald-700 border-emerald-200">
+                              CEE
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="font-semibold">{formatCurrency(quote.amount)}</TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2 text-sm">
+                          <Timer className="w-4 h-4 text-muted-foreground" />
+                          <span>{quote.validityDate}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className={statusMeta[quote.status].className}>
+                          {statusMeta[quote.status].label}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-2">
+                          <Button variant="ghost" size="icon">
+                            <Eye className="w-4 h-4" />
+                          </Button>
+                          <Button variant="ghost" size="icon">
+                            <Send className="w-4 h-4" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          <Card className="shadow-card bg-gradient-card border-0">
+            <CardHeader>
+              <CardTitle>Prochaines actions</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex gap-3 p-3 rounded-lg border bg-background/60">
+                <Send className="w-5 h-5 text-blue-500 mt-1" />
+                <div>
+                  <p className="font-medium">Relancer les devis envoyés</p>
+                  <p className="text-sm text-muted-foreground">
+                    {totals.sent} devis en attente de réponse depuis plus de 7 jours
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-3 p-3 rounded-lg border bg-background/60">
+                <CheckCircle2 className="w-5 h-5 text-green-500 mt-1" />
+                <div>
+                  <p className="font-medium">Convertir en facture</p>
+                  <p className="text-sm text-muted-foreground">
+                    {totals.accepted} devis acceptés prêts à être transformés en facture
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-3 p-3 rounded-lg border bg-background/60">
+                <Timer className="w-5 h-5 text-orange-500 mt-1" />
+                <div>
+                  <p className="font-medium">Expiration prochaine</p>
+                  <p className="text-sm text-muted-foreground">
+                    Vérifier les conditions commerciales avant la date limite
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default Quotes;


### PR DESCRIPTION
## Summary
- add a dedicated Devis dashboard with KPIs, filters, and quote list placeholders
- add a dedicated Factures dashboard including Factur-X readiness insights and relance guidance
- route /quotes and /invoices to the new pages so navigation surfaces the new views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbbf89e60c83339f3780052e7cfb2a