### PR TITLE
Implement full Supabase-backed leads workflow

### DIFF
--- a/docs/leads-review.md
+++ b/docs/leads-review.md
@@ -1,0 +1,28 @@
+# Leads Page Review
+
+This document summarizes the current implementation of `src/pages/Leads.tsx` and highlights the main gaps that prevent the page from being fully functional.
+
+## Current State
+- The UI renders using static `mockLeads` data defined inside `Leads.tsx`.
+- Filtering controls (search input and "Filtres" button) are present only as UI elements with no state or logic attached.
+- Action buttons such as "Importer CSV", "Planifier RDV", and "Créer Projet" do not have handlers behind them.
+
+## Identified Missing Pieces
+1. **Backend data integration**
+   - The page never queries Supabase for the authenticated user's leads. All information comes from the local `mockLeads` array, so the UI will not reflect the real database content.
+   - There is no loading or error state while fetching data from Supabase, nor any way to refresh the list.
+
+2. **Synchronization after creating a lead**
+   - `<AddLeadDialog />` accepts an optional `onLeadAdded` callback, but the page does not pass one in. As a result, adding a lead via the dialog will not update the list displayed on the page.
+
+3. **Filtering and search logic**
+   - The search input does not update component state or trigger any filtering. A filter button is displayed, but opening a filter panel or applying filters is not implemented.
+
+4. **Action handlers**
+   - The "Importer CSV" button should open a file picker or navigate to an import workflow, but no handler is provided.
+   - The "Planifier RDV" and "Créer Projet" buttons inside each lead card are placeholders without click behavior.
+
+5. **Data visualization and pagination**
+   - There is no aggregation (e.g., counts by status) or pagination/virtualization to handle large lead lists.
+
+These gaps need to be addressed to make the Leads page production-ready.

--- a/src/components/leads/ScheduleLeadDialog.tsx
+++ b/src/components/leads/ScheduleLeadDialog.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { supabase } from "@/integrations/supabase/client";
+import type { Tables } from "@/integrations/supabase/types";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Calendar as CalendarIcon, Loader2 } from "lucide-react";
+
+import {
+  getLeadStatusLabel,
+  isLeadStatus,
+  leadStatusEnum,
+  type LeadStatus,
+  LEAD_STATUSES,
+} from "./status";
+
+const scheduleSchema = z.object({
+  date_rdv: z.string().min(1, "La date du rendez-vous est requise"),
+  heure_rdv: z.string().min(1, "L'heure du rendez-vous est requise"),
+  status: leadStatusEnum,
+  commentaire: z.string().optional(),
+});
+
+type ScheduleLeadForm = z.infer<typeof scheduleSchema>;
+
+type LeadRecord = Tables<"leads">;
+
+interface ScheduleLeadDialogProps {
+  lead: LeadRecord;
+  onScheduled?: () => void | Promise<void>;
+}
+
+const resolveInitialStatus = (status: string): LeadStatus => {
+  if (isLeadStatus(status)) {
+    if (status === "NEW" || status === "QUALIFIED") {
+      return "RDV_PLANIFIE";
+    }
+    return status;
+  }
+  return "RDV_PLANIFIE";
+};
+
+export const ScheduleLeadDialog = ({ lead, onScheduled }: ScheduleLeadDialogProps) => {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
+
+  const form = useForm<ScheduleLeadForm>({
+    resolver: zodResolver(scheduleSchema),
+    defaultValues: {
+      date_rdv: lead.date_rdv ?? "",
+      heure_rdv: lead.heure_rdv ?? "",
+      commentaire: lead.commentaire ?? "",
+      status: resolveInitialStatus(lead.status),
+    },
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        date_rdv: lead.date_rdv ?? "",
+        heure_rdv: lead.heure_rdv ?? "",
+        commentaire: lead.commentaire ?? "",
+        status: resolveInitialStatus(lead.status),
+      });
+    }
+  }, [open, lead, form]);
+
+  const onSubmit = async (values: ScheduleLeadForm) => {
+    setLoading(true);
+    try {
+      const { error } = await supabase
+        .from("leads")
+        .update({
+          date_rdv: values.date_rdv,
+          heure_rdv: values.heure_rdv,
+          commentaire: values.commentaire?.trim() ? values.commentaire : null,
+          status: values.status,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", lead.id);
+
+      if (error) throw error;
+
+      toast({
+        title: "RDV planifié",
+        description: `Le rendez-vous avec ${lead.full_name} est enregistré`,
+      });
+
+      setOpen(false);
+      await onScheduled?.();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Une erreur inattendue est survenue";
+      toast({
+        title: "Erreur",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          Planifier RDV
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Planifier un rendez-vous</DialogTitle>
+          <DialogDescription>
+            Confirmez la date, l'heure et le statut du lead
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="date_rdv"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Date du RDV *</FormLabel>
+                    <FormControl>
+                      <Input type="date" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="heure_rdv"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Heure du RDV *</FormLabel>
+                    <FormControl>
+                      <Input type="time" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="status"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Statut du lead</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Choisir un statut" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {LEAD_STATUSES.map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {getLeadStatusLabel(status)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="commentaire"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Commentaire</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Notes internes, contexte supplémentaire..."
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+                Annuler
+              </Button>
+              <Button type="submit" disabled={loading}>
+                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Enregistrer le RDV
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/leads/status.ts
+++ b/src/components/leads/status.ts
@@ -1,0 +1,38 @@
+import * as z from "zod";
+
+export const LEAD_STATUSES = [
+  "NEW",
+  "QUALIFIED",
+  "RDV_PLANIFIE",
+  "CONVERTED",
+  "ARCHIVED",
+] as const satisfies readonly [string, ...string[]];
+
+export type LeadStatus = (typeof LEAD_STATUSES)[number];
+
+export const leadStatusEnum = z.enum(LEAD_STATUSES);
+
+const LEAD_STATUS_LABELS: Record<LeadStatus, string> = {
+  NEW: "Nouveau",
+  QUALIFIED: "Qualifié",
+  RDV_PLANIFIE: "RDV Planifié",
+  CONVERTED: "Converti",
+  ARCHIVED: "Archivé",
+};
+
+const LEAD_STATUS_COLORS: Record<LeadStatus, string> = {
+  NEW: "bg-blue-500/10 text-blue-700 border-blue-200",
+  QUALIFIED: "bg-orange-500/10 text-orange-700 border-orange-200",
+  RDV_PLANIFIE: "bg-purple-500/10 text-purple-700 border-purple-200",
+  CONVERTED: "bg-green-500/10 text-green-700 border-green-200",
+  ARCHIVED: "bg-gray-500/10 text-gray-700 border-gray-200",
+};
+
+export const isLeadStatus = (status: string): status is LeadStatus =>
+  LEAD_STATUSES.includes(status as LeadStatus);
+
+export const getLeadStatusLabel = (status: string) =>
+  isLeadStatus(status) ? LEAD_STATUS_LABELS[status] : status;
+
+export const getLeadStatusColor = (status: string) =>
+  isLeadStatus(status) ? LEAD_STATUS_COLORS[status] : "bg-gray-500/10 text-gray-700 border-gray-200";

--- a/src/pages/Leads.tsx
+++ b/src/pages/Leads.tsx
@@ -1,112 +1,456 @@
+import { useMemo, useRef, useState, type ChangeEvent } from "react";
+import { useQuery } from "@tanstack/react-query";
+
 import { Layout } from "@/components/layout/Layout";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AddLeadDialog } from "@/components/leads/AddLeadDialog";
-import { 
-  Search, 
-  Filter, 
-  Calendar, 
-  Phone, 
-  Mail, 
+import { ScheduleLeadDialog } from "@/components/leads/ScheduleLeadDialog";
+import { AddProjectDialog } from "@/components/projects/AddProjectDialog";
+import { supabase } from "@/integrations/supabase/client";
+import type { Tables } from "@/integrations/supabase/types";
+import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/hooks/use-toast";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  getLeadStatusColor,
+  getLeadStatusLabel,
+  isLeadStatus,
+  LEAD_STATUSES,
+  type LeadStatus,
+} from "@/components/leads/status";
+import {
+  Search,
+  Filter,
+  Calendar,
+  Phone,
+  Mail,
   MapPin,
   Building,
-  FileX
+  FileX,
+  AlertCircle,
+  Loader2,
 } from "lucide-react";
 
-interface Lead {
-  id: string;
+const CARD_SKELETON_COUNT = 4;
+
+type LeadRecord = Tables<"leads">;
+
+type CsvLead = {
   full_name: string;
-  company?: string;
   email: string;
   phone_raw: string;
   city: string;
   postal_code: string;
+  company?: string;
   product_name?: string;
   surface_m2?: number;
   utm_source?: string;
-  status: "NEW" | "QUALIFIED" | "RDV_PLANIFIE" | "CONVERTED" | "ARCHIVED";
+  status?: LeadStatus;
+  commentaire?: string;
   date_rdv?: string;
   heure_rdv?: string;
-  commentaire?: string;
-  created_at: string;
-}
-
-const mockLeads: Lead[] = [
-  {
-    id: "1",
-    full_name: "Marie Dupont",
-    company: "SARL Dupont",
-    email: "marie.dupont@email.com",
-    phone_raw: "06 12 34 56 78",
-    city: "Paris",
-    postal_code: "75015",
-    product_name: "Isolation Combles",
-    surface_m2: 120,
-    utm_source: "Google Ads",
-    status: "NEW",
-    commentaire: "Maison de 1970, intéressée par les aides CEE",
-    created_at: "2024-03-15T10:30:00Z"
-  },
-  {
-    id: "2",
-    full_name: "Jean Martin",
-    email: "j.martin@gmail.com",
-    phone_raw: "07 98 76 54 32",
-    city: "Lyon",
-    postal_code: "69003",
-    product_name: "Pompe à Chaleur",
-    surface_m2: 85,
-    utm_source: "Site Web",
-    status: "RDV_PLANIFIE",
-    date_rdv: "2024-03-20",
-    heure_rdv: "14:30",
-    commentaire: "Remplacement chaudière fioul",
-    created_at: "2024-03-14T15:20:00Z"
-  },
-  {
-    id: "3",
-    full_name: "Sophie Bernard",
-    company: "Cabinet Bernard",
-    email: "sophie@cabinet-bernard.fr",
-    phone_raw: "05 43 21 98 76",
-    city: "Toulouse",
-    postal_code: "31000",
-    product_name: "Panneaux Solaires",
-    surface_m2: 200,
-    utm_source: "Facebook",
-    status: "QUALIFIED",
-    commentaire: "Projet pour bureaux, budget 50k€",
-    created_at: "2024-03-13T09:15:00Z"
-  }
-];
-
-const getStatusLabel = (status: Lead["status"]) => {
-  const labels = {
-    NEW: "Nouveau",
-    QUALIFIED: "Qualifié",
-    RDV_PLANIFIE: "RDV Planifié",
-    CONVERTED: "Converti",
-    ARCHIVED: "Archivé"
-  };
-  return labels[status];
 };
 
-const getStatusColor = (status: Lead["status"]) => {
-  const colors = {
-    NEW: "bg-blue-500/10 text-blue-700 border-blue-200",
-    QUALIFIED: "bg-orange-500/10 text-orange-700 border-orange-200",
-    RDV_PLANIFIE: "bg-purple-500/10 text-purple-700 border-purple-200",
-    CONVERTED: "bg-green-500/10 text-green-700 border-green-200",
-    ARCHIVED: "bg-gray-500/10 text-gray-700 border-gray-200"
-  };
-  return colors[status];
+type CsvParseResult = {
+  rows: CsvLead[];
+  skipped: number;
+};
+
+const fetchLeads = async (): Promise<LeadRecord[]> => {
+  const { data, error } = await supabase
+    .from("leads")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Erreur lors du chargement des leads", error);
+    throw error;
+  }
+
+  return data ?? [];
+};
+
+const detectDelimiter = (line: string) => {
+  const commaCount = (line.match(/,/g) ?? []).length;
+  const semicolonCount = (line.match(/;/g) ?? []).length;
+  if (semicolonCount > commaCount) return ";";
+  if (commaCount > 0) return ",";
+  return ";";
+};
+
+const parseCsvLine = (line: string, delimiter: string) => {
+  const result: string[] = [];
+  let current = "";
+  let insideQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    const nextChar = line[i + 1];
+
+    if (char === "\"") {
+      if (insideQuotes && nextChar === "\"") {
+        current += "\"";
+        i++;
+      } else {
+        insideQuotes = !insideQuotes;
+      }
+    } else if (char === delimiter && !insideQuotes) {
+      result.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current.trim());
+
+  return result.map((value) => value.replace(/^"|"$/g, "").trim());
+};
+
+const normalizeHeader = (header: string) =>
+  header.trim().toLowerCase().replace(/[^a-z0-9]/g, "");
+
+const HEADER_MAPPINGS: Record<string, keyof CsvLead> = {
+  fullname: "full_name",
+  nom: "full_name",
+  name: "full_name",
+  client: "full_name",
+  email: "email",
+  courriel: "email",
+  mail: "email",
+  phone: "phone_raw",
+  telephone: "phone_raw",
+  tel: "phone_raw",
+  phoneraw: "phone_raw",
+  city: "city",
+  ville: "city",
+  locality: "city",
+  postalcode: "postal_code",
+  codepostal: "postal_code",
+  postal: "postal_code",
+  postal_code: "postal_code",
+  company: "company",
+  entreprise: "company",
+  societe: "company",
+  product: "product_name",
+  produit: "product_name",
+  productname: "product_name",
+  surface: "surface_m2",
+  surfacehabitable: "surface_m2",
+  surfacem2: "surface_m2",
+  surface_m2: "surface_m2",
+  utm: "utm_source",
+  utmsource: "utm_source",
+  source: "utm_source",
+  status: "status",
+  statut: "status",
+  commentaire: "commentaire",
+  comments: "commentaire",
+  note: "commentaire",
+  daterdv: "date_rdv",
+  date: "date_rdv",
+  heure: "heure_rdv",
+  heurerdv: "heure_rdv",
+};
+
+const parseCsv = (text: string): CsvParseResult => {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return { rows: [], skipped: 0 };
+  }
+
+  const delimiter = detectDelimiter(lines[0]);
+  const headers = parseCsvLine(lines[0], delimiter).map(normalizeHeader);
+
+  const rows: CsvLead[] = [];
+  let skipped = 0;
+
+  for (const line of lines.slice(1)) {
+    const values = parseCsvLine(line, delimiter);
+    if (values.every((value) => value.trim().length === 0)) {
+      continue;
+    }
+
+    const record: Partial<CsvLead> = {};
+
+    headers.forEach((header, index) => {
+      const key = HEADER_MAPPINGS[header];
+      if (!key) return;
+
+      const rawValue = values[index]?.trim() ?? "";
+      if (!rawValue) return;
+
+      switch (key) {
+        case "surface_m2": {
+          const parsed = Number.parseFloat(rawValue.replace(/,/, "."));
+          if (!Number.isNaN(parsed)) {
+            record.surface_m2 = parsed;
+          }
+          break;
+        }
+        case "status": {
+          const normalized = rawValue
+            .trim()
+            .toUpperCase()
+            .replace(/\s+/g, "_");
+          if (isLeadStatus(normalized)) {
+            record.status = normalized;
+          }
+          break;
+        }
+        case "date_rdv":
+        case "heure_rdv":
+        case "utm_source":
+        case "company":
+        case "product_name":
+        case "commentaire": {
+          // Preserve raw text
+          record[key] = rawValue;
+          break;
+        }
+        default: {
+          record[key] = rawValue;
+        }
+      }
+    });
+
+    if (
+      record.full_name &&
+      record.email &&
+      record.phone_raw &&
+      record.city &&
+      record.postal_code
+    ) {
+      rows.push(record as CsvLead);
+    } else {
+      skipped += 1;
+    }
+  }
+
+  return { rows, skipped };
+};
+
+const formatInitials = (fullName: string) => {
+  const parts = fullName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  const initials = parts.slice(0, 2).map((part) => part[0] ?? "").join("");
+  return initials.toUpperCase();
+};
+
+const generateProjectRef = (lead: LeadRecord) => {
+  const postal = lead.postal_code?.replace(/\s+/g, "").slice(0, 5) || "00000";
+  const suffix = lead.id.slice(0, 4).toUpperCase();
+  return `PRJ-${postal}-${suffix}`;
 };
 
 const Leads = () => {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedStatuses, setSelectedStatuses] = useState<LeadStatus[]>([]);
+  const [importing, setImporting] = useState(false);
+
+  const {
+    data: leads = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ["leads"],
+    queryFn: fetchLeads,
+  });
+
+  const filteredLeads = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return leads.filter((lead) => {
+      const matchesStatus =
+        selectedStatuses.length === 0 ||
+        (isLeadStatus(lead.status) && selectedStatuses.includes(lead.status as LeadStatus));
+
+      if (!matchesStatus) return false;
+
+      if (!normalizedSearch) return true;
+
+      const searchable = [
+        lead.full_name,
+        lead.email,
+        lead.phone_raw,
+        lead.city,
+        lead.postal_code,
+        lead.product_name ?? "",
+        lead.utm_source ?? "",
+        lead.company ?? "",
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      return searchable.includes(normalizedSearch);
+    });
+  }, [leads, searchTerm, selectedStatuses]);
+
+  const hasActiveFilters = Boolean(searchTerm.trim()) || selectedStatuses.length > 0;
+
+  const handleStatusFilterChange = (status: LeadStatus, checked: boolean | "indeterminate") => {
+    setSelectedStatuses((prev) => {
+      if (checked === true) {
+        if (prev.includes(status)) return prev;
+        return [...prev, status];
+      }
+      return prev.filter((item) => item !== status);
+    });
+  };
+
+  const handleImportClick = () => {
+    if (!user) {
+      toast({
+        title: "Connexion requise",
+        description: "Connectez-vous pour importer des leads",
+        variant: "destructive",
+      });
+      return;
+    }
+    fileInputRef.current?.click();
+  };
+
+  const handleCsvImport = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (!user) {
+      toast({
+        title: "Connexion requise",
+        description: "Connectez-vous pour importer des leads",
+        variant: "destructive",
+      });
+      event.target.value = "";
+      return;
+    }
+
+    setImporting(true);
+
+    try {
+      const text = await file.text();
+      const { rows, skipped } = parseCsv(text);
+
+      if (rows.length === 0) {
+        toast({
+          title: "Import invalide",
+          description: "Aucun lead valide n'a été détecté dans le fichier.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const payload = rows.map((row) => ({
+        user_id: user.id,
+        full_name: row.full_name,
+        email: row.email,
+        phone_raw: row.phone_raw,
+        city: row.city,
+        postal_code: row.postal_code,
+        status: row.status ?? "NEW",
+        company: row.company || undefined,
+        product_name: row.product_name || undefined,
+        surface_m2: row.surface_m2 || undefined,
+        utm_source: row.utm_source || undefined,
+        commentaire: row.commentaire || undefined,
+        date_rdv: row.date_rdv || undefined,
+        heure_rdv: row.heure_rdv || undefined,
+      }));
+
+      const { error: insertError } = await supabase.from("leads").insert(payload);
+      if (insertError) throw insertError;
+
+      toast({
+        title: "Import terminé",
+        description: `${rows.length} lead${rows.length > 1 ? "s" : ""} importé${
+          rows.length > 1 ? "s" : ""
+        }${
+          skipped
+            ? ` • ${skipped} ligne${skipped > 1 ? "s" : ""} ignorée${skipped > 1 ? "s" : ""}`
+            : ""
+        }`,
+      });
+
+      await refetch();
+    } catch (error) {
+      console.error("Erreur lors de l'import CSV", error);
+      const message = error instanceof Error ? error.message : "Vérifiez le format du fichier puis réessayez.";
+      toast({
+        title: "Erreur lors de l'import",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      event.target.value = "";
+      setImporting(false);
+    }
+  };
+
+  const handleLeadAdded = async () => {
+    await refetch();
+  };
+
+  const handleLeadScheduled = async () => {
+    await refetch();
+  };
+
+  const handleProjectCreated = async (lead: LeadRecord) => {
+    try {
+      if (lead.status !== "CONVERTED") {
+        const { error: updateError } = await supabase
+          .from("leads")
+          .update({ status: "CONVERTED", updated_at: new Date().toISOString() })
+          .eq("id", lead.id);
+
+        if (updateError) throw updateError;
+
+        toast({
+          title: "Lead converti",
+          description: `${lead.full_name} est maintenant marqué comme converti.`,
+        });
+      }
+    } catch (error) {
+      console.error("Erreur lors de la mise à jour du lead", error);
+      const message = error instanceof Error ? error.message : "Réessayez plus tard.";
+      toast({
+        title: "Impossible de mettre à jour le lead",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      await refetch();
+    }
+  };
+
   return (
     <Layout>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".csv"
+        onChange={handleCsvImport}
+        className="hidden"
+      />
       <div className="space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">
@@ -115,15 +459,19 @@ const Leads = () => {
               Gestion des Leads
             </h1>
             <p className="text-muted-foreground mt-1">
-              Prospection et qualification des demandes entrantes
+              Prospection et qualification des demandes entrantes synchronisées avec Supabase
             </p>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline">
-              <FileX className="w-4 h-4 mr-2" />
-              Importer CSV
+            <Button variant="outline" onClick={handleImportClick} disabled={importing}>
+              {importing ? (
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              ) : (
+                <FileX className="w-4 h-4 mr-2" />
+              )}
+              {importing ? "Import en cours" : "Importer CSV"}
             </Button>
-            <AddLeadDialog />
+            <AddLeadDialog onLeadAdded={handleLeadAdded} />
           </div>
         </div>
 
@@ -133,120 +481,193 @@ const Leads = () => {
             <div className="flex flex-col md:flex-row gap-4">
               <div className="relative flex-1">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                <Input 
-                  placeholder="Rechercher par nom, email, téléphone..." 
+                <Input
+                  placeholder="Rechercher par nom, email, téléphone..."
                   className="pl-10"
+                  value={searchTerm}
+                  onChange={(event) => setSearchTerm(event.target.value)}
                 />
               </div>
-              <Button variant="outline">
-                <Filter className="w-4 h-4 mr-2" />
-                Filtres
-              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline">
+                    <Filter className="w-4 h-4 mr-2" />
+                    {selectedStatuses.length > 0
+                      ? `Filtres (${selectedStatuses.length})`
+                      : "Filtres"}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-60">
+                  <DropdownMenuLabel>Filtrer par statut</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {LEAD_STATUSES.map((status) => (
+                    <DropdownMenuCheckboxItem
+                      key={status}
+                      checked={selectedStatuses.includes(status)}
+                      onCheckedChange={(checked) => handleStatusFilterChange(status, checked)}
+                    >
+                      {getLeadStatusLabel(status)}
+                    </DropdownMenuCheckboxItem>
+                  ))}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => setSelectedStatuses([])}>
+                    Réinitialiser les filtres
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </CardContent>
         </Card>
 
+        {isError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Impossible de charger les leads</AlertTitle>
+            <AlertDescription>
+              {error?.message ?? "Vérifiez votre connexion Supabase puis réessayez."}
+            </AlertDescription>
+            <div className="mt-4">
+              <Button variant="outline" onClick={() => refetch()}>
+                Réessayer
+              </Button>
+            </div>
+          </Alert>
+        )}
+
         {/* Leads Table */}
         <Card className="shadow-card bg-gradient-card border-0">
-          <CardHeader>
-            <CardTitle>Leads Récents ({mockLeads.length})</CardTitle>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <div>
+              <CardTitle>Leads Récents ({filteredLeads.length})</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                {hasActiveFilters ? `${leads.length} leads au total` : "Données à jour depuis Supabase"}
+              </p>
+            </div>
+            {isLoading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              {mockLeads.map((lead) => (
-                <div 
-                  key={lead.id} 
-                  className="p-4 rounded-lg border bg-card hover:bg-muted/50 transition-colors"
-                >
-                  <div className="flex items-start justify-between mb-3">
-                    <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 rounded-full bg-gradient-to-br from-primary/20 to-accent/20 flex items-center justify-center">
-                        <span className="font-semibold text-primary">
-                          {lead.full_name.split(' ').map(n => n[0]).join('').toUpperCase()}
-                        </span>
+            {isLoading ? (
+              <div className="space-y-4">
+                {Array.from({ length: CARD_SKELETON_COUNT }).map((_, index) => (
+                  <div
+                    key={index}
+                    className="h-24 rounded-lg border bg-muted/20 animate-pulse"
+                  />
+                ))}
+              </div>
+            ) : filteredLeads.length === 0 ? (
+              <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+                {hasActiveFilters
+                  ? "Aucun lead ne correspond aux filtres sélectionnés."
+                  : "Aucun lead pour le moment. Ajoutez-en un nouveau ou importez un fichier CSV."}
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {filteredLeads.map((lead) => (
+                  <div
+                    key={lead.id}
+                    className="p-4 rounded-lg border bg-card hover:bg-muted/50 transition-colors"
+                  >
+                    <div className="flex items-start justify-between mb-3">
+                      <div className="flex items-center gap-3">
+                        <div className="w-10 h-10 rounded-full bg-gradient-to-br from-primary/20 to-accent/20 flex items-center justify-center">
+                          <span className="font-semibold text-primary">
+                            {formatInitials(lead.full_name)}
+                          </span>
+                        </div>
+                        <div>
+                          <h3 className="font-semibold text-foreground">
+                            {lead.full_name}
+                          </h3>
+                          {lead.company && (
+                            <p className="text-sm text-muted-foreground flex items-center gap-1">
+                              <Building className="w-3 h-3" />
+                              {lead.company}
+                            </p>
+                          )}
+                        </div>
                       </div>
-                      <div>
-                        <h3 className="font-semibold text-foreground">
-                          {lead.full_name}
-                        </h3>
-                        {lead.company && (
-                          <p className="text-sm text-muted-foreground flex items-center gap-1">
-                            <Building className="w-3 h-3" />
-                            {lead.company}
-                          </p>
+                      <Badge className={getLeadStatusColor(lead.status)}>
+                        {getLeadStatusLabel(lead.status)}
+                      </Badge>
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-3">
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2 text-sm">
+                          <Phone className="w-4 h-4 text-muted-foreground" />
+                          {lead.phone_raw}
+                        </div>
+                        <div className="flex items-center gap-2 text-sm">
+                          <Mail className="w-4 h-4 text-muted-foreground" />
+                          {lead.email}
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2 text-sm">
+                          <MapPin className="w-4 h-4 text-muted-foreground" />
+                          {lead.city} ({lead.postal_code})
+                        </div>
+                        {lead.product_name && (
+                          <div className="text-sm">
+                            <span className="font-medium">{lead.product_name}</span>
+                            {lead.surface_m2 && (
+                              <span className="text-muted-foreground"> • {lead.surface_m2} m²</span>
+                            )}
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="space-y-2">
+                        {lead.date_rdv && lead.heure_rdv && (
+                          <div className="flex items-center gap-2 text-sm">
+                            <Calendar className="w-4 h-4 text-primary" />
+                            <span className="text-primary font-medium">
+                              {new Date(lead.date_rdv).toLocaleDateString("fr-FR")} à {lead.heure_rdv}
+                            </span>
+                          </div>
+                        )}
+                        {lead.utm_source && (
+                          <div className="text-sm text-muted-foreground">
+                            Source: {lead.utm_source}
+                          </div>
                         )}
                       </div>
                     </div>
-                    <Badge className={getStatusColor(lead.status)}>
-                      {getStatusLabel(lead.status)}
-                    </Badge>
-                  </div>
 
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-3">
-                    <div className="space-y-2">
-                      <div className="flex items-center gap-2 text-sm">
-                        <Phone className="w-4 h-4 text-muted-foreground" />
-                        {lead.phone_raw}
+                    {lead.commentaire && (
+                      <div className="mb-3 p-3 bg-muted/50 rounded text-sm">
+                        {lead.commentaire}
                       </div>
-                      <div className="flex items-center gap-2 text-sm">
-                        <Mail className="w-4 h-4 text-muted-foreground" />
-                        {lead.email}
-                      </div>
-                    </div>
+                    )}
 
-                    <div className="space-y-2">
-                      <div className="flex items-center gap-2 text-sm">
-                        <MapPin className="w-4 h-4 text-muted-foreground" />
-                        {lead.city} ({lead.postal_code})
+                    <div className="flex items-center justify-between pt-3 border-t">
+                      <span className="text-xs text-muted-foreground">
+                        Créé le {new Date(lead.created_at).toLocaleDateString("fr-FR")}
+                      </span>
+                      <div className="flex gap-2">
+                        <ScheduleLeadDialog lead={lead} onScheduled={handleLeadScheduled} />
+                        <AddProjectDialog
+                          trigger={<Button size="sm">Créer Projet</Button>}
+                          initialValues={{
+                            project_ref: generateProjectRef(lead),
+                            client_name: lead.full_name,
+                            company: lead.company ?? "",
+                            product_name: lead.product_name ?? "",
+                            city: lead.city,
+                            postal_code: lead.postal_code,
+                            surface_isolee_m2: lead.surface_m2 ?? undefined,
+                            lead_id: lead.id,
+                          }}
+                          onProjectAdded={() => handleProjectCreated(lead)}
+                        />
                       </div>
-                      {lead.product_name && (
-                        <div className="text-sm">
-                          <span className="font-medium">{lead.product_name}</span>
-                          {lead.surface_m2 && <span className="text-muted-foreground"> • {lead.surface_m2} m²</span>}
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="space-y-2">
-                      {lead.date_rdv && lead.heure_rdv && (
-                        <div className="flex items-center gap-2 text-sm">
-                          <Calendar className="w-4 h-4 text-primary" />
-                          <span className="text-primary font-medium">
-                            {new Date(lead.date_rdv).toLocaleDateString('fr-FR')} à {lead.heure_rdv}
-                          </span>
-                        </div>
-                      )}
-                      {lead.utm_source && (
-                        <div className="text-sm text-muted-foreground">
-                          Source: {lead.utm_source}
-                        </div>
-                      )}
                     </div>
                   </div>
-
-                  {lead.commentaire && (
-                    <div className="mb-3 p-3 bg-muted/50 rounded text-sm">
-                      {lead.commentaire}
-                    </div>
-                  )}
-
-                  <div className="flex items-center justify-between pt-3 border-t">
-                    <span className="text-xs text-muted-foreground">
-                      Créé le {new Date(lead.created_at).toLocaleDateString('fr-FR')}
-                    </span>
-                    <div className="flex gap-2">
-                      <Button size="sm" variant="outline">
-                        <Calendar className="w-4 h-4 mr-1" />
-                        Planifier RDV
-                      </Button>
-                      <Button size="sm">
-                        Créer Projet
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- replace the mock data on the Leads page with a Supabase-powered query, client-side search & status filtering, and CSV import with validation feedback
- add a reusable lead status helper plus a scheduling dialog that updates rendez-vous data and refreshes the Supabase cache
- enhance the project creation dialog so the Leads page can prefill projects from a lead and automatically mark the lead as converted

## Testing
- npm run lint *(fails: existing lint errors in shared UI components, Auth page, Quotes page, and tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcdf47e5c833396c47b74cfc15763