### PR TITLE
Fix Nouveau chantier modal responsiveness

### DIFF
--- a/src/components/sites/SiteDialog.tsx
+++ b/src/components/sites/SiteDialog.tsx
@@ -223,7 +223,7 @@ export const SiteDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl">
+      <DialogContent className="max-w-3xl w-[95vw] sm:w-full max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {mode === "create" ? "Nouveau chantier" : "Modifier le chantier"}


### PR DESCRIPTION
## Summary
- allow the Nouveau chantier dialog to use nearly full viewport width on small screens
- enforce a max height with internal scrolling so the modal content remains reachable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc35f7e41c8333bb00514706998f48